### PR TITLE
Fix abrupt cut-over to vsUTCS soundtrack

### DIFF
--- a/vegastrike.config
+++ b/vegastrike.config
@@ -1016,7 +1016,8 @@ This is done many times later in this config file
 <!-- #audio_off music_only
       <var name="Sound" value="false"/>
 #end -->
-      <var name="battleplaylist" value="battle.m3u"/>
+      <var name="loading_sound" value="../music/opening.ogg"/>
+	  <var name="battleplaylist" value="battle.m3u"/>
       <var name="peaceplaylist" value="peace.m3u"/>
       <var name="panicplaylist" value="panic.m3u"/>
       <var name="threadtime" value="1"/>


### PR DESCRIPTION
Fixes https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/515 by adding `loading_sound` setting to vegastrike.config. The correct opening / loading soundtrack then plays.